### PR TITLE
Fix abort handling in dynamo fetch

### DIFF
--- a/analyses/constraints/src/dynamo/dynamo.js
+++ b/analyses/constraints/src/dynamo/dynamo.js
@@ -40,12 +40,10 @@ export async function run(code, state) {
 
     return { data: await response.json(), type: "success" };
   } catch (e) {
-    if (e.name === "AbortError") {
-      if (signal.reason === "aborting previous request") {
-        return { type: "aborted" };
-      } else {
-        throw Error("Request timed out after 30 seconds");
-      }
+    if (e === "aborting previous request") {
+      return { type: "aborted" };
+    } else if (e === "timeout") {
+      throw Error("Request timed out after 30 seconds");
     } else {
       throw e;
     }


### PR DESCRIPTION
Stumbled upon this in a code search, figured I might quickly help fix this to avoid future confusion.

If a reason is provided to the abort method of AbortController, it will be thrown directly. It will not be wrapped in an AbortError.

This could alternatively be fixed by aborting with Error objects, but this is the simpler method.